### PR TITLE
Made the assets example compile.

### DIFF
--- a/examples/05_assets/main.rs
+++ b/examples/05_assets/main.rs
@@ -1,227 +1,138 @@
-//! Demonstrates several assets-related techniques, including writing a custom
-//! asset loader, and loading assets from various paths.
-//!
-//! TODO: Rewrite for new renderer.
+//! Demostrates loading custom assets using the Amethyst engine.
+// TODO: Add asset loader directory store for the meshes.
 
 extern crate amethyst;
 extern crate cgmath;
 
-use amethyst::{Application, State, Trans};
-use amethyst::asset_manager::{AssetLoader, AssetLoaderRaw, AssetManager, Assets, DirectoryStore};
+use amethyst::{Application, Error, State, Trans};
 use amethyst::config::Config;
 use amethyst::ecs::World;
-use amethyst::ecs::components::{LocalTransform, Mesh, Texture, Transform};
-use amethyst::ecs::resources::{Camera, Projection, ScreenDimensions};
-use amethyst::ecs::systems::TransformSystem;
-use amethyst::gfx_device::DisplayConfig;
-use amethyst::renderer::{Layer, PointLight, Pipeline, VertexPosNormal};
-use amethyst::renderer::pass::{Clear, DrawShaded};
-use cgmath::{Deg, Euler, Quaternion};
-use std::env::set_var;
-use std::str;
+use amethyst::ecs::resources::input::InputHandler;
+use amethyst::prelude::*;
+use amethyst::renderer::{Camera, Config as DisplayConfig};
+use amethyst::renderer::prelude::*;
 
-// Implement custom asset loader that reads files with a simple format of
-// 1 vertex and 1 normal per line, with coordinates separated by whitespace.
-struct CustomObj {
-    vertices: Vec<[f32; 3]>,
-    normals: Vec<[f32; 3]>,
-}
+struct AssetsExample;
 
-impl AssetLoaderRaw for CustomObj {
-    fn from_raw(_: &Assets, data: &[u8]) -> Option<CustomObj> {
-        let data: String = str::from_utf8(data).unwrap().into();
-        let mut vertices = Vec::new();
-        let mut normals = Vec::new();
+impl State for AssetsExample {
+    fn on_start(&mut self, engine: &mut Engine) {
+        let input = InputHandler::new();
+        engine.world.add_resource(input);
 
-        let trimmed: Vec<&str> = data.lines().filter(|line| line.len() >= 1).collect();
+        initialise_camera(&mut engine.world.write_resource::<Camera>());
+        initialise_lights(&mut engine.world);
 
-        for line in trimmed {
-            let nums: Vec<&str> = line.split_whitespace().collect();
-
-            vertices.push([nums[0].parse::<f32>().unwrap(),
-                           nums[1].parse::<f32>().unwrap(),
-                           nums[2].parse::<f32>().unwrap()]);
-
-            normals.push([nums[3].parse::<f32>().unwrap(),
-                          nums[4].parse::<f32>().unwrap(),
-                          nums[5].parse::<f32>().unwrap()]);
-        }
-
-        Some(CustomObj {
-                 vertices: vertices,
-                 normals: normals,
-             })
-    }
-}
-
-impl AssetLoader<Mesh> for CustomObj {
-    fn from_data(assets: &mut Assets, obj: CustomObj) -> Option<Mesh> {
-        let vertices = obj.vertices
-            .iter()
-            .zip(obj.normals.iter())
-            .map(|(v, n)| {
-                     VertexPosNormal {
-                         pos: v.clone(),
-                         normal: n.clone(),
-                         tex_coord: [0.0, 0.0],
-                     }
-                 })
-            .collect::<Vec<_>>();
-        AssetLoader::<Mesh>::from_data(assets, vertices)
-    }
-}
-
-struct Example;
-
-impl State for Example {
-    fn on_start(&mut self, world: &mut World, assets: &mut AssetManager, pipe: &mut Pipeline) {
-        {
-            let dim = world.read_resource::<ScreenDimensions>();
-            let mut camera = world.write_resource::<Camera>();
-            let proj = Projection::Perspective {
-                fov: 60.0,
-                aspect_ratio: dim.aspect_ratio,
-                near: 1.0,
-                far: 100.0,
-            };
-            camera.proj = proj;
-            camera.eye = [0.0, -20.0, 10.0];
-            camera.target = [0.0, 0.0, 5.0];
-            camera.up = [0.0, 0.0, 1.0];
-        }
-
-        // Set up an assets path by directly registering an assets store.
-        let assets_path = format!("{}/examples/05_assets/resources/meshes",
-                                  env!("CARGO_MANIFEST_DIR"));
-        assets.register_store(DirectoryStore::new(assets_path));
-
-        // Create some basic colors for the teapot, and load some textures
-        // for the cube and sphere.
-        assets.load_asset_from_data::<Texture, [f32; 4]>("dark_blue", [0.0, 0.0, 0.1, 1.0]);
-        assets.load_asset_from_data::<Texture, [f32; 4]>("green", [0.0, 1.0, 0.2, 1.0]);
-        assets.load_asset_from_data::<Texture, [f32; 4]>("tan", [0.8, 0.6, 0.5, 1.0]);
-        assets.load_asset_from_data::<Texture, [f32; 4]>("white", [1.0, 1.0, 1.0, 1.0]);
-        assets.load_asset::<Texture>("crate", "png");
-        assets.load_asset::<Texture>("grass", "bmp");
-
-        // Load/generate meshes
-        assets.load_asset::<Mesh>("teapot", "obj");
-        assets.load_asset::<Mesh>("lid", "obj");
-        assets.load_asset::<Mesh>("cube", "obj");
-        assets.load_asset::<Mesh>("sphere", "obj");
-
-        // Also add custom asset loader and load mesh
-        assets.register_loader::<Mesh, CustomObj>("custom");
-        assets.load_asset::<Mesh>("cuboid", "custom");
-
-        // Add teapot and lid to scene
-        for mesh in vec!["lid", "teapot"].iter() {
-            let mut trans = LocalTransform::default();
-            trans.rotation = Quaternion::from(Euler::new(Deg(90.0), Deg(-90.0), Deg(0.0))).into();
-            trans.translation = [5.0, 0.0, 5.0];
-            let rend = assets
-                .create_renderable(mesh, "dark_blue", "green", "white", 1.0)
-                .unwrap();
-            world
-                .create_entity()
-                .with(rend)
-                .with(trans)
-                .with(Transform::default())
-                .build();
-        }
-
-        // Add custom cube object to scene
-        let rend = assets
-            .create_renderable("cuboid", "dark_blue", "green", "white", 1.0)
-            .unwrap();
-        let mut trans = LocalTransform::default();
-        trans.translation = [-5.0, 0.0, 0.0];
-        trans.scale = [2.0, 2.0, 2.0];
-        world
-            .create_entity()
-            .with(rend)
-            .with(trans)
-            .with(Transform::default())
-            .build();
-
-        // Add cube to scene
-        let rend = assets
-            .create_renderable("cube", "crate", "tan", "white", 1.0)
-            .unwrap();
-        let mut trans = LocalTransform::default();
-        trans.translation = [5.0, 0.0, 0.0];
-        trans.scale = [2.0, 2.0, 2.0];
-        world
-            .create_entity()
-            .with(rend)
-            .with(trans)
-            .with(Transform::default())
-            .build();
-
-        // Add sphere to scene
-        let rend = assets
-            .create_renderable("sphere", "grass", "green", "white", 1.0)
-            .unwrap();
-        let mut trans = LocalTransform::default();
-        trans.translation = [-5.0, 0.0, 7.5];
-        trans.rotation = Quaternion::from(Euler::new(Deg(90.0), Deg(0.0), Deg(0.0))).into();
-        trans.scale = [0.15, 0.15, 0.15];
-        world
-            .create_entity()
-            .with(rend)
-            .with(trans)
-            .with(Transform::default())
-            .build();
-
-        // Add light to scene
-        let light = PointLight {
-            center: [5.0, -20.0, 15.0],
-            intensity: 10.0,
-            radius: 100.0,
-            ..Default::default()
-        };
-
-        world.create_entity().with(light).build();
-
-        // Set up rendering pipeline
-        let layer = Layer::new("main",
-                               vec![Clear::new([0.0, 0.0, 0.0, 1.0]),
-                                    DrawShaded::new("main", "main")]);
-        pipe.layers.push(layer);
+        // TODO: Load colours, textures and meshes.
+        // Meshes to load: teapot.obj, lid.obj, cube.obj, sphere.obj
+        // Textures to load: crate.png, grass.bmp
     }
 
-    fn handle_events(&mut self,
-                     events: &[WindowEvent],
-                     _: &mut World,
-                     _: &mut AssetManager,
-                     _: &mut Pipeline)
-                     -> Trans {
-        // Exit if user hits Escape or closes the window
-        for e in events {
-            match **e {
-                Event::KeyboardInput(_, _, Some(VirtualKeyCode::Escape)) => return Trans::Quit,
-                Event::Closed => return Trans::Quit,
-                _ => (),
+    fn handle_event(&mut self, engine: &mut Engine, event: Event) -> Trans {
+        let mut input = engine.world.write_resource::<InputHandler>();
+        match event {
+            Event::WindowEvent { event, .. } => {
+                match event {
+                    WindowEvent::Closed |
+                    WindowEvent::KeyboardInput {
+                        input: KeyboardInput {
+                            virtual_keycode: Some(VirtualKeyCode::Escape),
+                            ..
+                        },
+                        ..
+                    } => {
+                        // If the user pressed the escape key, or requested the window to be closed,
+                        // quit the application.
+                        Trans::Quit
+                    }
+                    _ => {
+                        // If we didn't handle the event, forward it to the input handler.
+                        input.update(&[event]);
+                        Trans::None
+                    }
+                }
             }
+            _ => Trans::None,
         }
-        Trans::None
     }
 }
 
 fn main() {
+    if let Err(error) = run() {
+        eprintln!("Could not run the example!");
+        eprintln!("{}", error);
+        ::std::process::exit(1);
+    }
+}
+
+/// Wrapper around the main, so we can return errors easily.
+fn run() -> Result<(), Error> {
+    use amethyst::ecs::components::{Child, Init, LocalTransform, Transform};
+    use amethyst::ecs::systems::TransformSystem;
+    use std::env::set_var;
+
     // Set up an assets path by setting an environment variable. Note that
     // this would normally be done with something like this:
     //
     //     AMETHYST_ASSET_DIRS=/foo/bar cargo run
-    let assets_path = format!("{}/examples/05_assets/resources/textures",
-                              env!("CARGO_MANIFEST_DIR"));
+    let assets_path = format!(
+        "{}/examples/05_assets/resources/textures",
+        env!("CARGO_MANIFEST_DIR")
+    );
     set_var("AMETHYST_ASSET_DIRS", assets_path);
 
-    let path = format!("{}/examples/05_assets/resources/config.ron",
-                       env!("CARGO_MANIFEST_DIR"));
-    let cfg = DisplayConfig::load(path);
-    let mut game = Application::build(Example, cfg)
+    let path = format!(
+        "{}/examples/05_assets/resources/config.ron",
+        env!("CARGO_MANIFEST_DIR")
+    );
+
+    let display_config = DisplayConfig::load(path);
+    let pipeline_builder = Pipeline::build().with_stage(
+        Stage::with_backbuffer()
+            .clear_target([0.0, 0.0, 0.0, 1.0], 1.0)
+            .with_model_pass(pass::DrawFlat::<PosNormTex>::new()),
+    );
+
+    let mut game = Application::build(AssetsExample)
+        .expect("Failed to build ApplicationBuilder for an unknown reason.")
+        .register::<Child>()
+        .register::<LocalTransform>()
+        .register::<Init>()
         .with::<TransformSystem>(TransformSystem::new(), "transform_system", &[])
-        .done();
+        .with_renderer(pipeline_builder, Some(display_config))?
+        .build()?;
+
     game.run();
+    Ok(())
+}
+
+
+/// Initialises the camera structure.
+fn initialise_camera(camera: &mut Camera) {
+    use cgmath::Deg;
+
+    // TODO: Fix the aspect ratio.
+    camera.proj = Projection::perspective(1.0, Deg(60.0)).into();
+    camera.eye = [0.0, -20.0, 10.0].into();
+
+    camera.forward = [0., 0., -1.0].into();
+    camera.right = [1.0, 0.0, 0.0].into();
+    camera.up = [0., 1.0, 0.].into();
+}
+
+/// Adds lights to the scene.
+fn initialise_lights(world: &mut World) {
+    use amethyst::ecs::components::LightComponent;
+    use amethyst::renderer::light::PointLight;
+
+    let light = PointLight {
+        center: [5.0, -20.0, 15.0].into(),
+        intensity: 10.0,
+        radius: 100.0,
+        ..Default::default()
+    };
+
+    world
+        .create_entity()
+        .with(LightComponent(light.into()))
+        .build();
 }

--- a/examples/05_assets/main.rs
+++ b/examples/05_assets/main.rs
@@ -66,7 +66,8 @@ fn main() {
 
 /// Wrapper around the main, so we can return errors easily.
 fn run() -> Result<(), Error> {
-    use amethyst::ecs::components::{Child, Init, LocalTransform, Transform};
+    use amethyst::assets::Directory;
+    use amethyst::ecs::components::{Child, Init, LocalTransform};
     use amethyst::ecs::systems::TransformSystem;
     use std::env::set_var;
 
@@ -74,18 +75,24 @@ fn run() -> Result<(), Error> {
     // this would normally be done with something like this:
     //
     //     AMETHYST_ASSET_DIRS=/foo/bar cargo run
-    let assets_path = format!(
+    let textures_path = format!(
         "{}/examples/05_assets/resources/textures",
         env!("CARGO_MANIFEST_DIR")
     );
-    set_var("AMETHYST_ASSET_DIRS", assets_path);
+    set_var("AMETHYST_ASSET_DIRS", textures_path);
 
-    let path = format!(
+    // Add our meshes directory to the asset loader.
+    let mesh_directory = format!(
+        "{}/examples/05_assets/resources/meshes",
+        env!("CARGO_MANIFEST_DIR")
+    );
+
+    let display_config_path = format!(
         "{}/examples/05_assets/resources/config.ron",
         env!("CARGO_MANIFEST_DIR")
     );
 
-    let display_config = DisplayConfig::load(path);
+    let display_config = DisplayConfig::load(display_config_path);
     let pipeline_builder = Pipeline::build().with_stage(
         Stage::with_backbuffer()
             .clear_target([0.0, 0.0, 0.0, 1.0], 1.0)
@@ -99,6 +106,7 @@ fn run() -> Result<(), Error> {
         .register::<Init>()
         .with::<TransformSystem>(TransformSystem::new(), "transform_system", &[])
         .with_renderer(pipeline_builder, Some(display_config))?
+        .add_store("meshes", Directory::new(mesh_directory))
         .build()?;
 
     game.run();


### PR DESCRIPTION
This moves the assets example to the new renderer as well as to the new input handler (although it does not use the new `actions` system yet). It still
crashes shortly after starting up, because of some resources/components not being registered. These should be registered outside of the example, and are
waiting for a future commit.

This removes nearly all if not all asset related functionality. Asset loading has not been implemented yet. Most notably, these changes would be required:

 - `assets::Directory` cannot be instantiated as there is no way to get an `assets::Allocator` from the `assets::Loader`.
 - Object/mesh files and texture files are waiting on PR #297

All removed code has been replaced with appropriate 'TODO's.

Additionally, this commit reformatted the example and split it up into various function, to make it easier to read. The initialisation of the lights and the camera are now fitted in their own function. The `run()` function prevents uses of `.unwrap()` and `.expect()`, and instead returns any errors to `main()` which can then print them out.